### PR TITLE
Article EditorでPHPからJavaScriptへの値の受け渡しにURL encodingを使ふ

### DIFF
--- a/lib/Ranyuen/Controller/AdminArticlesController.php
+++ b/lib/Ranyuen/Controller/AdminArticlesController.php
@@ -47,13 +47,9 @@ class AdminArticlesController extends AdminController
                 return $router->error(404, $req);
             }
         }
-        $json = json_encode($article);
-        $json = str_replace('\\"', '\\\\"', $json);
-        $json = str_replace('\\s', '\\\\\\s', $json);
-        // $json = preg_replace('#\\[^nr]#', '\\\\\\$0', $json);
         return $this->renderer->render(
             'admin/articles/edit',
-            ['article' => $json]
+            ['article' => rawurlencode(json_encode($article))]
         );
     }
 

--- a/lib/Ranyuen/Controller/AdminArticlesController.php
+++ b/lib/Ranyuen/Controller/AdminArticlesController.php
@@ -122,6 +122,6 @@ class AdminArticlesController extends AdminController
      */
     public function preview($content)
     {
-        return (new Template($content))->render();
+        return $this->renderer->renderContent($content);
     }
 }

--- a/lib/Ranyuen/Template/MainViewRenderer.php
+++ b/lib/Ranyuen/Template/MainViewRenderer.php
@@ -61,7 +61,7 @@ class MainViewRenderer
     }
 
     /**
-     * 日本語版 / 英語版の対応をとります。.
+     * 日本語版 / 英語版の対応をとります。
      *
      * @param string $lang Current lang.
      * @param string $path URI path info.

--- a/view/admin/articles/edit.markdown
+++ b/view/admin/articles/edit.markdown
@@ -30,16 +30,8 @@ title: Edit article
 <script src="/assets/javascripts/article_editor.min.js"></script>
 <script>
 var editor,
-    article = '{{article}}';
-article = article.
-  replace(/\t/g,     '  ').
-  replace(/\n/g,     '\\n').
-  replace(/\r/g,     '\\r').
-  replace(/&lt;/g,   '<').
-  replace(/&gt;/g,   '>').
-  replace(/&quot;/g, '"').
-  replace(/&#039;/g, "'").
-  replace(/&amp;/g,  '&');
+    article = '{{article | raw}}';
+article = decodeURIComponent(article);
 article = JSON.parse(article);
 article = article ? Article.fromJson(article) : new Article();
 window.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
Fix #103 